### PR TITLE
Add RAWG games coverflow

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -118,3 +118,18 @@ img {
   pointer-events: none;
   mix-blend-mode: multiply;
 }
+
+.scroll-minimal {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--color-ink) 30%, transparent) transparent;
+}
+
+.scroll-minimal::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.scroll-minimal::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--color-ink) 30%, transparent);
+  border-radius: 999px;
+}

--- a/app/components/layout/SiteShell.tsx
+++ b/app/components/layout/SiteShell.tsx
@@ -7,6 +7,7 @@ const navItems = [
   { label: "Projects", to: "/projects" },
   { label: "Articles", to: "/articles" },
   { label: "Books", to: "/books" },
+  { label: "Games", to: "/games" },
 ];
 
 export function SiteShell({ children }: { children: React.ReactNode }) {

--- a/app/data/games.json
+++ b/app/data/games.json
@@ -1,0 +1,383 @@
+[
+  {
+    "id": 906547,
+    "slug": "hogwarts-legacy",
+    "title": "Hogwarts Legacy",
+    "description": "Hogwarts Legacy is an immersive, open-world action RPG set in the world first introduced in the Harry Potter books. Now you can take control of the action and be at the center of your own adventure in the wizarding world. Embark on a journey through familiar and new locations as you explore and discover fantastic beasts, customize your character and craft potions, master spell casting, upgrade talents, and become the wizard you want to be.\r\n\r\nExperience Hogwarts in the 1800s. Your character is a student who holds the key to an ancient secret that threatens to tear the wizarding world apart. You have received a late acceptance to the Hogwarts School of Witchcraft and Wizardry and soon discover that you are no ordinary student: you possess an unusual ability to perceive and master Ancient Magic. Only you can decide if you will protect this secret for the good of all, or yield to the temptation of more sinister magic.\r\n\r\nDiscover the feeling of living at Hogwarts as you make allies, battle Dark wizards, and ultimately decide the fate of the wizarding world. Your legacy is what you make of it.",
+    "released": "2023-02-10",
+    "backgroundImage": "https://media.rawg.io/media/games/044/044b2ee023930ca138deda151f40c18c.jpg",
+    "genres": [
+      "Action",
+      "RPG"
+    ],
+    "developers": [
+      "Avalanche Software",
+      "Portkey Games"
+    ],
+    "platforms": [
+      "PC",
+      "PlayStation 5",
+      "Xbox Series S/X",
+      "PlayStation 4",
+      "Nintendo Switch",
+      "Xbox One"
+    ],
+    "rating": 3.93,
+    "metacritic": null,
+    "website": "https://www.hogwartslegacy.com/",
+    "rawgUrl": "https://rawg.io/games/hogwarts-legacy",
+    "featured": false
+  },
+  {
+    "id": 682502,
+    "slug": "the-dark-pictures-anthology-the-devil-in-me",
+    "title": "The Dark Pictures Anthology: The Devil In Me",
+    "description": "A series of stand-alone branching cinematic horror games from the studio behind Until Dawn. Easy to pick-up and play in short sessions, alone or with friends. The Devil in Me is the fourth game in the series and the Season One finale.   \r\n\r\n \r\nA group of documentary film makers receive a mysterious call inviting them to a modern-day replica of serial killer H.H. Holmes’ ‘Murder Castle’. It’s an opportunity that’s too good to pass up and could be just the thing they’re looking for to win some much-needed public interest.\r\n \r\n\r\nThe hotel is the perfect set for their new episode, but things aren’t quite as they seem. The crew discover they’re being watched and even manipulated, and suddenly there’s much more at stake than just their ratings!",
+    "released": "2022-11-17",
+    "backgroundImage": "https://media.rawg.io/media/games/ab0/ab0381be59467a6c54a858c6ab65a5a5.jpg",
+    "genres": [
+      "Action",
+      "Adventure"
+    ],
+    "developers": [
+      "Supermassive Games"
+    ],
+    "platforms": [
+      "PlayStation 5",
+      "Xbox Series S/X",
+      "PC",
+      "PlayStation 4",
+      "Xbox One"
+    ],
+    "rating": 3.3,
+    "metacritic": null,
+    "website": "https://www.thedarkpictures.com/",
+    "rawgUrl": "https://rawg.io/games/the-dark-pictures-anthology-the-devil-in-me",
+    "featured": false
+  },
+  {
+    "id": 514896,
+    "slug": "the-dark-pictures-anthology-house-of-ashes",
+    "title": "The Dark Pictures Anthology: House of Ashes",
+    "description": "Iraq, 2003. In the shadow of the Zagros mountains a military unit comes under fire from Iraqi forces. The resulting firefight causes an earth tremor where both sides fall into the ruins of a buried Sumerian temple. With all communication severed, our protagonists are trapped in a terrifying underworld they must navigate to escape - unaware that something ancient and evil has awakened in the shadows and has found a new prey to hunt.\r\n\r\nHorrific discoveries and impossible decisions now face the survivors as they strive to escape the terrifying threat they awakened. Will they each prioritize their own survival, or put aside their fears and personal rivalries to fight together as one against these underworld monsters?",
+    "released": "2021-10-22",
+    "backgroundImage": "https://media.rawg.io/media/games/326/326cbbdc3bc2da0b10cc3f7edd57161a.jpg",
+    "genres": [
+      "Action",
+      "Adventure"
+    ],
+    "developers": [
+      "Supermassive Games"
+    ],
+    "platforms": [
+      "PlayStation 5",
+      "Xbox One",
+      "PlayStation 4",
+      "PC",
+      "Xbox Series S/X"
+    ],
+    "rating": 3.89,
+    "metacritic": 73,
+    "website": "https://www.thedarkpictures.com/",
+    "rawgUrl": "https://rawg.io/games/the-dark-pictures-anthology-house-of-ashes",
+    "featured": false
+  },
+  {
+    "id": 326251,
+    "slug": "deathloop-2",
+    "title": "Deathloop",
+    "description": "“DEATHLOOP” transports players to the lawless island of Blackreef in an eternal struggle between two extraordinary assassins. Explore stunning environments and meticulously designed levels in an immersive gameplay experience that lets you approach every situation any way you like. Hunt down targets all over the island in an effort to put an end to the cycle once and for all, and remember, if at first you don’t succeed… die, die again.",
+    "released": "2021-09-14",
+    "backgroundImage": "https://media.rawg.io/media/games/018/01857c5ff9579c48fa8bd76b4d83a946.jpg",
+    "genres": [
+      "Action",
+      "RPG"
+    ],
+    "developers": [
+      "Arkane Studios"
+    ],
+    "platforms": [
+      "PlayStation 5",
+      "PC",
+      "Xbox Series S/X"
+    ],
+    "rating": 3.96,
+    "metacritic": 88,
+    "website": "https://bethesda.net/en/game/deathloop",
+    "rawgUrl": "https://rawg.io/games/deathloop-2",
+    "featured": false
+  },
+  {
+    "id": 369158,
+    "slug": "the-dark-pictures-anthology-little-hope",
+    "title": "The Dark Pictures Anthology: Little Hope",
+    "description": "The Dark Pictures Anthology is a series of intense, standalone, branching cinematic horror games featuring single and multiplayer modes.\n\n4 college students and their professor become stranded in the abandoned town of Little Hope. Trapped by an impenetrable fog they try desperately to escape whilst witnessing terrifying visions from the past. They must figure out the motivation of these apparitions before the evil forces at work drags each of their souls to hell.\n\nWitness terrifying visions of the past, haunted by the events of the XVIIth century Andover Witch Trials\n\nEscape the hideous apparitions that relentlessly pursue them through the fog!\n\nPlay online with a friend or up to 5 friends offline.\n\nAbandon Hope...all who enter here!",
+    "released": "2020-10-30",
+    "backgroundImage": "https://media.rawg.io/media/games/643/6431f15213a854efd273943f2cf6a925.jpg",
+    "genres": [
+      "Action",
+      "Adventure"
+    ],
+    "developers": [
+      "Supermassive Games"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "PC",
+      "Nintendo Switch",
+      "Xbox One"
+    ],
+    "rating": 3.79,
+    "metacritic": 70,
+    "website": "https://www.thedarkpictures.com/",
+    "rawgUrl": "https://rawg.io/games/the-dark-pictures-anthology-little-hope",
+    "featured": false
+  },
+  {
+    "id": 274755,
+    "slug": "hades-2018",
+    "title": "Hades",
+    "description": "Hades is a rogue-like dungeon crawler that combines the best aspects of Supergiant's critically acclaimed titles, including the fast-paced action of Bastion, the rich atmosphere and depth of Transistor, and the character-driven storytelling of Pyre.\n\nBATTLE OUT OF HELL\nAs the immortal Prince of the Underworld, you'll wield the powers and mythic weapons of Olympus to break free from the clutches of the god of the dead himself, while growing stronger and unraveling more of the story with each unique escape attempt.\n\nUNLEASH THE FURY OF OLYMPUS\nThe Olympians have your back! Meet Zeus, Athena, Poseidon, and many more, and choose from their dozens of powerful Boons that enhance your abilities. There are thousands of viable character builds to discover as you go.\n\nBEFRIEND GODS, GHOSTS, AND MONSTERS\nA fully-voiced cast of colorful, larger-than-life characters is waiting to meet you! Grow your relationships with them, and experience hundreds of unique story events as you learn about what's really at stake for this big, dysfunctional family.\n\nBUILT FOR REPLAYABILITY\nNew surprises await each time you delve into the ever-shifting Underworld, whose guardian bosses will remember you. Use the powerful Mirror of Night to grow permanently stronger, and give yourself a leg up the next time you run away from home.\n\nNOTHING IS IMPOSSIBLE\nPermanent upgrades mean you don't have to be a god yourself to experience the exciting combat and gripping story. Though, if you happen to be one, crank up the challenge and get ready for some white-knuckle action that will put your well-practiced skills to the test.\n\nSIGNATURE SUPERGIANT STYLE\nThe rich, atmospheric presentation and unique melding of gameplay and narrative that's been core to Supergiant's games is here in full force: spectacular hand-painted Underworld environments and a blood-pumping original score bring the Underworld to life.",
+    "released": "2020-09-17",
+    "backgroundImage": "https://media.rawg.io/media/games/1f4/1f47a270b8f241e4676b14d39ec620f7.jpg",
+    "genres": [
+      "Action",
+      "Adventure",
+      "RPG",
+      "Indie"
+    ],
+    "developers": [
+      "Supergiant Games"
+    ],
+    "platforms": [
+      "PlayStation 5",
+      "Xbox Series S/X",
+      "PlayStation 4",
+      "Nintendo Switch",
+      "PC",
+      "Xbox One"
+    ],
+    "rating": 4.42,
+    "metacritic": 93,
+    "website": "https://www.supergiantgames.com/games/hades/",
+    "rawgUrl": "https://rawg.io/games/hades-2018",
+    "featured": false
+  },
+  {
+    "id": 339961,
+    "slug": "man-of-medan",
+    "title": "The Dark Pictures Anthology: Man of Medan",
+    "description": "The Dark Pictures Anthology is a series of stand-alone, branching cinematic horror games featuring a multiplayer mode.\n\nIn Man of Medan, five friends set sail on a holiday diving trip that soon changes into something much more sinister...\n\nEmbark on a horrific journey aboard a ghost ship.\n\nExperience your terrifying story with a friend online or go for safety in numbers with up to five players offline\n\nAll playable characters can live or die. The choices you make will decide their fate.\n\nWho will you save?\n\nDon't. Play. Alone.",
+    "released": "2019-08-30",
+    "backgroundImage": "https://media.rawg.io/media/games/206/2060eda39e4646bbe90b55ab7495c173.jpg",
+    "genres": [
+      "Action",
+      "Adventure"
+    ],
+    "developers": [
+      "Supermassive Games"
+    ],
+    "platforms": [
+      "PC",
+      "Nintendo Switch",
+      "PlayStation 4",
+      "Xbox One"
+    ],
+    "rating": 3.62,
+    "metacritic": 71,
+    "website": "https://www.thedarkpictures.com/",
+    "rawgUrl": "https://rawg.io/games/man-of-medan",
+    "featured": false
+  },
+  {
+    "id": 47137,
+    "slug": "fornite-battle-royale",
+    "title": "Fortnite Battle Royale",
+    "description": "Fortnite Battle Royale is the completely free 100-player PvP mode in Fortnite. One giant map. A battle bus. Fortnite building skills and destructible environments combined with intense PvP combat. The last one standing wins.  Download now for FREE and jump into the action.\r\nThis download also gives you a path to purchase the Save the World co-op PvE campaign during Fortnite’s Early Access season, or instant access if you received a Friend invite.\r\nOnline features require an account and are subject to terms of service and applicable privacy policy (playstationnetwork.com/terms-of-service & playstationnetwork.com/privacy-policy).\r\n1 player\r\nNetwork Players 2-99\r\n10GB minimum save size\r\nDUALSHOCK®4\r\nOnline Play (Required)\r\nSoftware subject to license (us.playstation.com/softwarelicense). Online features require an account and are subject to terms of service and applicable privacy policy (playstationnetwork.com/terms-of-service & playstationnetwork.com/privacy-policy).\r\nFortnite © 2017, Epic Games, Inc. Epic Games, Fortnite, Unreal, Unreal Engine 4, UE4, and their respective logos are trademarks or registered trademarks of Epic Games, Inc. in the United States of America and elsewhere. All rights reserved. The rating icon is a registered trademark of the Entertainment Software Association. All other trademarks and trade names are the properties of their respective owners.",
+    "released": "2017-09-26",
+    "backgroundImage": "https://media.rawg.io/media/games/dcb/dcbb67f371a9a28ea38ffd73ee0f53f3.jpg",
+    "genres": [
+      "Action",
+      "Shooter"
+    ],
+    "developers": [
+      "Epic Games"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "Xbox One",
+      "iOS",
+      "PC",
+      "Android",
+      "Xbox Series S/X",
+      "PlayStation 5",
+      "Nintendo Switch"
+    ],
+    "rating": 3.28,
+    "metacritic": null,
+    "website": "https://www.epicgames.com/fortnite",
+    "rawgUrl": "https://rawg.io/games/fornite-battle-royale",
+    "featured": false
+  },
+  {
+    "id": 3209,
+    "slug": "until-dawn",
+    "title": "Until Dawn",
+    "description": "Ten young people spend time in a cottage on a mountain. Around the cottage, there is a forest and something supernatural. First, they joke with each other, then unknown and deadly participants appear in the game.\nSome people will die in any case, the lives of others will depend on the player. There will also be helpers - one of them will tell you that the mountain is inhabited by Wendigo - supernatural beings who were once human beings, but after eating people’s flesh they became obsessed with evil spirits and turned into bloodthirsty monsters.\nWendigo will be settled in some of the dead characters - and they will come to life and will get superpowers that help win even the Wendigo.\nThe plot is ramified so that you will have to go through the game several times to familiarise with all the options.\nThe player has to make decisions quickly, conduct investigations, collect and take into account numerous clues. Actually, this is the gameplay.",
+    "released": "2015-08-25",
+    "backgroundImage": "https://media.rawg.io/media/games/d64/d6443375f9971152866ea76bff97d6d6.jpg",
+    "genres": [
+      "Action",
+      "Adventure"
+    ],
+    "developers": [
+      "Supermassive Games"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "PlayStation 3"
+    ],
+    "rating": 4.1,
+    "metacritic": 79,
+    "website": "http://www.supermassivegames.com/index.php/games/until-dawn",
+    "rawgUrl": "https://rawg.io/games/until-dawn",
+    "featured": false
+  },
+  {
+    "id": 4062,
+    "slug": "bioshock-infinite",
+    "title": "BioShock Infinite",
+    "description": "The third game in the series, Bioshock takes the story of the underwater confinement within the lost city of Rapture and takes it in the sky-city of Columbia. Players will follow Booker DeWitt, a private eye with a military past; as he will attempt to wipe his debts with the only skill he’s good at – finding people. Aside from obvious story and style differences, this time Bioshock protagonist has a personality, character, and voice, no longer the protagonist is a silent man, trying to survive.\r\nOpen and bright level design of Columbia shows industrial colonial America in a seemingly endless carnival. But Bioshock is not famous for its visuals, but for its story.  Mystery and creative vision of Irrational Games invite players to uncover the secrets of Columbia’s leader - Zachary Comstock and save Elizabeth, the girl, that’s been locked up in the flying city since her birth.\r\nUnique weapons and mechanics of Vigor will make encounters different, helping players to adjust to the new found mobility and hook shot, making fights fast-paced and imaginative.",
+    "released": "2013-03-26",
+    "backgroundImage": "https://media.rawg.io/media/games/fc1/fc1307a2774506b5bd65d7e8424664a7.jpg",
+    "genres": [
+      "Action",
+      "Shooter"
+    ],
+    "developers": [
+      "Aspyr Media",
+      "2K Australia",
+      "Irrational Games"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "Xbox 360",
+      "Nintendo Switch",
+      "Linux",
+      "PC",
+      "PlayStation 3",
+      "Xbox One"
+    ],
+    "rating": 4.38,
+    "metacritic": 94,
+    "website": "https://2k.com/en-US/game/bioshock-infinite",
+    "rawgUrl": "https://rawg.io/games/bioshock-infinite",
+    "featured": false
+  },
+  {
+    "id": 4248,
+    "slug": "dishonored",
+    "title": "Dishonored",
+    "description": "Dishonored is the game about stealth. Or action and killing people. It is you who will decide what to do with your enemies. You play as Corvo Attano, Empress' bodyguard, a masterful assassin and a combat specialist. All of a sudden, a group of assassins kill the Empress and kidnaps her daughter Emily. Being accused of murder and waiting for execution in a cell, Corvo still manages to escape with the help of the Loyalists and their leader Admiral Havelock. Now it is your duty to return the Empress daughter and restore your name. The main focus of the game is to give the player a choice. You can spare the lives of your enemies by knocking them out or making others do the job for you or brutally murder everyone in the city. Gadgets are given by Piero Joplin, Loyalists engineer and by the Outsider, who gives Corvo magical abilities. The game reacts to your choices - grim atmosphere by itself can be turned even darker by killing people or slightly lighter by not doing so. It is only a player's choice what to do with his abilities. Basing on these actions the game will give you with two different endings of the story.",
+    "released": "2012-09-25",
+    "backgroundImage": "https://media.rawg.io/media/games/4e6/4e6e8e7f50c237d76f38f3c885dae3d2.jpg",
+    "genres": [
+      "Action",
+      "Adventure",
+      "RPG"
+    ],
+    "developers": [
+      "Bethesda Softworks",
+      "Arkane Studios"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "PlayStation 3",
+      "Xbox 360",
+      "PC",
+      "Xbox One"
+    ],
+    "rating": 4.38,
+    "metacritic": 91,
+    "website": "http://www.dishonored.com",
+    "rawgUrl": "https://rawg.io/games/dishonored",
+    "featured": false
+  },
+  {
+    "id": 52372,
+    "slug": "pokemon-ruby",
+    "title": "Pokémon Ruby, Sapphire, Emerald",
+    "description": "The race to catch 'em all is on again in Pokémon Ruby. This entry in the Pokémon series features an all-new storyline, awesome new Pokémon, and addictive RPG gameplay. One of the biggest additions to Pokémon Ruby is the two-on-two battle system, which allows you to link up with three friends to battle competitively or cooperatively. You can also showcase your Pokémon's coolness, beauty, cuteness, smartness, and toughness in Pokémon contests. With new Pokémon, two-on-two battles, and an all-new region of Hoenn to explore, Pokémon Sapphire takes the Pokémon experience to the next level.",
+    "released": "2004-09-16",
+    "backgroundImage": "https://media.rawg.io/media/screenshots/7e5/7e56cc0421adcea354ed6b85057f2caa.jpeg",
+    "genres": [
+      "Adventure",
+      "RPG"
+    ],
+    "developers": [
+      "Game Freak",
+      "Creatures"
+    ],
+    "platforms": [
+      "Game Boy Advance"
+    ],
+    "rating": 4.38,
+    "metacritic": 76,
+    "website": "",
+    "rawgUrl": "https://rawg.io/games/pokemon-ruby",
+    "featured": false
+  },
+  {
+    "id": 51432,
+    "slug": "wolf-among-us-2",
+    "title": "The Wolf Among Us 2",
+    "description": "Play as Bigby, “The Big Bad Wolf” and Sheriff of Fabletown, as you return to a gritty detective noir world where there are no fairy tale endings.\r\n\r\nThe Wolf Among Us 2 picks up six months after the events of season one. It’s winter in New York City and a new case threatens to cross the line between Fabletown and the NYPD. How you choose to approach it could determine the future of the Fable community.",
+    "released": null,
+    "backgroundImage": "https://media.rawg.io/media/games/845/84539f8f33fea2c753cca0ce3a6d168f.jpg",
+    "genres": [
+      "Adventure"
+    ],
+    "developers": [
+      "Telltale Games",
+      "Adhoc Games"
+    ],
+    "platforms": [
+      "Xbox Series S/X",
+      "PlayStation 4",
+      "PC",
+      "Xbox One",
+      "PlayStation 5"
+    ],
+    "rating": 3.5,
+    "metacritic": null,
+    "website": "https://www.telltale.com/the-wolf-among-us-2/",
+    "rawgUrl": "https://rawg.io/games/wolf-among-us-2",
+    "featured": false
+  },
+  {
+    "id": 573118,
+    "slug": "gothic-1-remake",
+    "title": "Gothic 1 Remake",
+    "description": "The Kingdom of Myrtana has been invaded by an implacable horde of orcs.\nKing Rhobar II, in need of a large quantity of magical ore in order to forge powerful weapons, operates the Khorinis mines with all available prisoners. To prevent them from escaping, the monarch asks his best magicians to create a magical barrier. But something goes wrong. The magic gets out of control and a mutiny turns the mines into a wild territory now controlled by the most violent prisoners.\nThe King is forced to negotiate with the new owners, while the tension between the different factions of the mines increases. What no one expects is that the arrival of an unknown prisoner will change absolutely everything.\n\nFeatures:\n\n- Faithful full remake of the original Gothic 1.\n\n- Modernized combat system that takes the basic premises of the original combat system to the modern age.\n\n- Return to The Colony, in a full blown remake of the popular and revolutionary game Gothic from 2001. Rediscover the world of the mining colony, its secrets and challenges.\n\n- Play as the Nameless Hero – Manage the fate of a lifetime convicted prisoner who must survive in a world of wild animals, creatures and convicts of dangerous reputation.",
+    "released": null,
+    "backgroundImage": "https://media.rawg.io/media/screenshots/6e2/6e22b48b86209ab927f19677341ef9b2.jpg",
+    "genres": [
+      "Action",
+      "RPG"
+    ],
+    "developers": [
+      "Piranha Bytes",
+      "Alkimia Interactive"
+    ],
+    "platforms": [
+      "PlayStation 4",
+      "Xbox One",
+      "PC"
+    ],
+    "rating": 3,
+    "metacritic": null,
+    "website": "https://alkimiainteractive.com/",
+    "rawgUrl": "https://rawg.io/games/gothic-1-remake",
+    "featured": false
+  }
+]

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -8,6 +8,7 @@ export default [
   route("projects/:slug", "routes/projects.$slug.tsx"),
   route("books", "routes/books.tsx"),
   route("books/:slug", "routes/books.$slug.tsx"),
+  route("games", "routes/games.tsx"),
   route("content/*", "routes/content.tsx"),
   route(":slug", "routes/page.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -1,0 +1,529 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Route } from "./+types/games";
+import gamesData from "~/data/games.json";
+
+const groupOptions = [
+  { value: "none", label: "None" },
+  { value: "genre", label: "Genre" },
+  { value: "studio", label: "Studio" },
+] as const;
+
+const filterOptions = [
+  { value: "all", label: "All" },
+  { value: "top", label: "Top rated" },
+  { value: "recent", label: "Recent" },
+] as const;
+
+type Game = {
+  id: number | string;
+  slug?: string | null;
+  title: string;
+  released?: string | null;
+  backgroundImage?: string | null;
+  description?: string | null;
+  genres?: string[] | null;
+  developers?: string[] | null;
+  platforms?: string[] | null;
+  rating?: number | null;
+  metacritic?: number | null;
+  website?: string | null;
+  rawgUrl?: string | null;
+  featured?: boolean | null;
+};
+
+type GroupBy = (typeof groupOptions)[number]["value"];
+type FilterBy = (typeof filterOptions)[number]["value"];
+
+export function meta() {
+  return [
+    { title: "Games · Christian Cito" },
+    {
+      name: "description",
+      content: "Favorite games, studios, and playable worlds.",
+    },
+  ];
+}
+
+export async function loader() {
+  return { games: gamesData as Game[] };
+}
+
+function normalizeText(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function getPrimaryStudio(game: Game) {
+  return game.developers?.[0] ?? "Unknown studio";
+}
+
+function getPrimaryGenre(game: Game) {
+  return game.genres?.[0] ?? "Other";
+}
+
+function getGroupKey(game: Game, groupBy: GroupBy) {
+  if (groupBy === "genre") return getPrimaryGenre(game);
+  if (groupBy === "studio") return getPrimaryStudio(game);
+  return "";
+}
+
+export default function Games({ loaderData }: Route.ComponentProps) {
+  const games = loaderData.games ?? [];
+  const [groupBy, setGroupBy] = useState<GroupBy>("none");
+  const [filterBy, setFilterBy] = useState<FilterBy>("all");
+  const [query, setQuery] = useState("");
+  const [flowOpen, setFlowOpen] = useState(false);
+  const [flowIndex, setFlowIndex] = useState(0);
+  const [barCollapsed, setBarCollapsed] = useState(false);
+  const flowRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredGames = useMemo(() => {
+    const normalizedQuery = normalizeText(query);
+    const currentYear = new Date().getFullYear();
+
+    return games.filter((game) => {
+      if (filterBy === "top" && (game.rating ?? 0) < 4) return false;
+      if (filterBy === "recent") {
+        const year = game.released ? Number(game.released.slice(0, 4)) : 0;
+        if (year < currentYear - 4) return false;
+      }
+
+      if (!normalizedQuery) return true;
+
+      const haystack = [
+        game.title,
+        getPrimaryStudio(game),
+        game.genres?.join(" "),
+        game.platforms?.join(" "),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [games, filterBy, query]);
+
+  const orderedGames = useMemo(() => {
+    const items = [...filteredGames];
+    if (groupBy === "none") return items;
+    return items.sort((a, b) => {
+      const groupA = getGroupKey(a, groupBy).toLowerCase();
+      const groupB = getGroupKey(b, groupBy).toLowerCase();
+      if (groupA === groupB) return a.title.localeCompare(b.title);
+      return groupA.localeCompare(groupB);
+    });
+  }, [filteredGames, groupBy]);
+
+  const flowGames = orderedGames;
+  const safeFlowIndex = Math.min(
+    flowIndex,
+    Math.max(flowGames.length - 1, 0),
+  );
+  const activeGame = flowGames[safeFlowIndex];
+
+  const scrollToIndex = (index: number) => {
+    const container = flowRef.current;
+    if (!container) return;
+    const slide = container.querySelector<HTMLDivElement>(
+      `[data-flow-index="${index}"]`,
+    );
+    slide?.scrollIntoView({ behavior: "smooth", inline: "start" });
+  };
+
+  const clampIndex = (index: number) =>
+    Math.max(0, Math.min(index, Math.max(flowGames.length - 1, 0)));
+
+  const goToIndex = (index: number) => {
+    const nextIndex = clampIndex(index);
+    setFlowIndex(nextIndex);
+    scrollToIndex(nextIndex);
+  };
+
+  const handlePrev = () => {
+    goToIndex(safeFlowIndex - 1);
+  };
+
+  const handleNext = () => {
+    goToIndex(safeFlowIndex + 1);
+  };
+
+  const openFlow = (game: Game) => {
+    const index = flowGames.findIndex((item) => item.id === game.id);
+    const nextIndex = index >= 0 ? index : 0;
+    setFlowIndex(nextIndex);
+    setFlowOpen(true);
+    setBarCollapsed(false);
+    setTimeout(() => scrollToIndex(nextIndex), 0);
+  };
+
+  useEffect(() => {
+    if (!flowOpen) return;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalHtmlOverflow = document.documentElement.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalHtmlOverflow;
+    };
+  }, [flowOpen]);
+
+  return (
+    <div className="relative flex h-[calc(100dvh-9rem)] flex-col overflow-hidden">
+      <header className="flex h-20 items-center justify-between gap-4 rounded-[1.25rem] border border-white/10 bg-black/55 px-4 backdrop-blur">
+        <div className="flex items-center gap-3">
+          <h1 className="font-[var(--font-display)] text-xl font-semibold text-[color:var(--color-ink)]">
+            Games
+          </h1>
+          <span className="text-xs uppercase tracking-[0.3em] text-white/50">
+            {orderedGames.length} titles
+          </span>
+        </div>
+
+        <div className="flex flex-1 items-center justify-end gap-3">
+          <select
+            aria-label="Group games"
+            value={groupBy}
+            onChange={(event) => setGroupBy(event.target.value as GroupBy)}
+            className="h-8 rounded-full border border-white/10 bg-black/50 px-3 text-[10px] uppercase tracking-[0.3em] text-white/70"
+          >
+            {groupOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                Group: {option.label}
+              </option>
+            ))}
+          </select>
+          <select
+            aria-label="Filter games"
+            value={filterBy}
+            onChange={(event) => setFilterBy(event.target.value as FilterBy)}
+            className="h-8 rounded-full border border-white/10 bg-black/50 px-3 text-[10px] uppercase tracking-[0.3em] text-white/70"
+          >
+            {filterOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search"
+            className="h-8 w-32 rounded-full border border-white/10 bg-black/40 px-3 text-xs text-white/80 placeholder:text-white/40 md:w-48"
+          />
+          <a
+            href="https://rawg.io"
+            target="_blank"
+            rel="noreferrer"
+            className="hidden text-[10px] uppercase tracking-[0.3em] text-white/40 hover:text-white/70 md:inline"
+          >
+            RAWG
+          </a>
+        </div>
+      </header>
+
+      <div
+        className={[
+          "scroll-minimal flex-1 px-1 py-6",
+          flowOpen ? "overflow-y-hidden" : "overflow-y-auto",
+        ].join(" ")}
+      >
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+          {orderedGames.length
+            ? orderedGames.map((game) => (
+                <article key={game.id} className="group">
+                  <button
+                    type="button"
+                    onClick={() => openFlow(game)}
+                    className="flex w-full flex-col gap-3 text-left"
+                  >
+                    <div className="relative aspect-square overflow-hidden rounded-[1.8rem] border border-white/10 bg-black/50 shadow-[0_25px_60px_-45px_rgba(0,0,0,0.9)]">
+                      {game.backgroundImage ? (
+                        <img
+                          src={game.backgroundImage}
+                          alt={game.title}
+                          className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-white/10 via-white/5 to-black/40 text-xs uppercase tracking-[0.3em] text-white/60">
+                          Cover coming
+                        </div>
+                      )}
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+                      <div className="absolute bottom-4 left-4 right-4 flex items-center justify-between text-[10px] uppercase tracking-[0.35em] text-white/70">
+                        <span>{getPrimaryGenre(game)}</span>
+                        <span>{game.released?.slice(0, 4) ?? ""}</span>
+                      </div>
+                    </div>
+                    <div className="space-y-1 px-1">
+                      <p className="text-sm font-semibold text-[color:var(--color-ink)]">
+                        {game.title}
+                      </p>
+                      <p className="text-xs text-white/60">
+                        {getPrimaryStudio(game)}
+                      </p>
+                      <p className="text-[10px] uppercase tracking-[0.35em] text-white/40">
+                        Open in RAWG ↗
+                      </p>
+                    </div>
+                  </button>
+                </article>
+              ))
+            : Array.from({ length: 12 }).map((_, index) => (
+                <div
+                  key={`placeholder-${index}`}
+                  className="space-y-3 rounded-[1.8rem] border border-white/10 bg-white/5 p-4"
+                  aria-hidden
+                >
+                  <div className="aspect-square rounded-[1.4rem] border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-black/40" />
+                  <div className="space-y-2">
+                    <div className="h-3 w-3/4 rounded-full bg-white/10" />
+                    <div className="h-3 w-1/2 rounded-full bg-white/5" />
+                  </div>
+                </div>
+              ))}
+        </div>
+      </div>
+
+      {flowOpen ? (
+        <section className="fixed inset-x-0 top-20 bottom-0 z-40 flex flex-col overflow-hidden border-t border-white/10 bg-black">
+          <div className="pointer-events-none absolute inset-0">
+            {activeGame?.backgroundImage ? (
+              <>
+                <div
+                  className="absolute inset-0 scale-110 bg-center bg-cover blur-[60px] brightness-75 saturate-125"
+                  style={{ backgroundImage: `url(${activeGame.backgroundImage})` }}
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-black/20 via-black/70 to-black/95" />
+              </>
+            ) : (
+              <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/70 to-black" />
+            )}
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <div
+              ref={flowRef}
+              onScroll={(event) => {
+                const target = event.currentTarget;
+                const width = target.clientWidth || 1;
+                const nextIndex = Math.round(target.scrollLeft / width);
+                if (nextIndex !== flowIndex) setFlowIndex(nextIndex);
+              }}
+              className="scroll-minimal relative z-10 flex h-full snap-x snap-mandatory overflow-x-auto overflow-y-hidden scroll-smooth"
+            >
+              {flowGames.map((game, index) => (
+                <article
+                  key={game.id}
+                  data-flow-index={index}
+                  className="scroll-minimal h-full w-full shrink-0 snap-start overflow-y-auto"
+                >
+                  <div className="flex min-h-full flex-col gap-6 px-6 py-8 lg:flex-row lg:gap-10">
+                    <div className="self-start lg:sticky lg:top-6">
+                      <div className="relative aspect-[3/4] w-60 overflow-hidden rounded-[1.4rem] border border-white/15 bg-white/5 shadow-[var(--shadow-soft)] sm:w-72 lg:w-80">
+                        {game.backgroundImage ? (
+                          <img
+                            src={game.backgroundImage}
+                            alt={game.title}
+                            className="h-full w-full object-cover"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-white/10 via-white/5 to-black/40 text-xs uppercase tracking-[0.3em] text-white/60">
+                            Cover
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex-1 space-y-6 pb-10">
+                      <div className="space-y-2">
+                        <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                          {getPrimaryStudio(game)}
+                        </p>
+                        <h2 className="font-[var(--font-display)] text-3xl font-semibold text-[color:var(--color-ink)]">
+                          {game.title}
+                        </h2>
+                        <p className="text-sm text-white/60">
+                          Released {game.released ?? "—"}
+                        </p>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2">
+                        {(game.genres ?? []).map((genre) => (
+                          <span
+                            key={genre}
+                            className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.24em] text-white/70"
+                          >
+                            {genre}
+                          </span>
+                        ))}
+                        {(game.platforms ?? []).map((platform) => (
+                          <span
+                            key={platform}
+                            className="rounded-full border border-white/5 bg-black/50 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/50"
+                          >
+                            {platform}
+                          </span>
+                        ))}
+                      </div>
+
+                      {game.description ? (
+                        <p className="max-w-prose text-sm leading-relaxed text-white/70">
+                          {game.description}
+                        </p>
+                      ) : null}
+
+                      <div className="grid gap-3 rounded-[1.2rem] border border-white/10 bg-white/5 p-5 text-sm text-white/70">
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs uppercase tracking-[0.3em] text-white/40">
+                            Rating
+                          </span>
+                          <span>{game.rating?.toFixed(1) ?? "—"}</span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs uppercase tracking-[0.3em] text-white/40">
+                            Metacritic
+                          </span>
+                          <span>{game.metacritic ?? "—"}</span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs uppercase tracking-[0.3em] text-white/40">
+                            Studio
+                          </span>
+                          <span>{getPrimaryStudio(game)}</span>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-3">
+                        {game.website ? (
+                          <a
+                            href={game.website}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="pressable rounded-full border border-[color:var(--color-brand)] bg-[color:var(--color-brand)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-black shadow-[var(--shadow-glow)]"
+                          >
+                            Official site
+                          </a>
+                        ) : null}
+                        {game.rawgUrl ? (
+                          <a
+                            href={game.rawgUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="pressable rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70 hover:border-white/30 hover:text-white"
+                          >
+                            RAWG
+                          </a>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <div
+            className={[
+              "relative z-10 flex flex-col border-t border-white/10 bg-black/70",
+              barCollapsed ? "h-16" : "h-[30vh] min-h-[180px]",
+            ].join(" ")}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3 px-6 py-3">
+              <div
+                className={[
+                  "space-y-1",
+                  barCollapsed ? "hidden sm:block" : "",
+                ].join(" ")}
+              >
+                <p className="text-[10px] uppercase tracking-[0.3em] text-white/50">
+                  Now viewing
+                </p>
+                <p className="text-sm font-semibold text-[color:var(--color-ink)]">
+                  {activeGame?.title ?? "Select a game"}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handlePrev}
+                  className="pressable rounded-full border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-white/70 hover:border-white/30 hover:text-white"
+                >
+                  ←
+                </button>
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="pressable rounded-full border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-white/70 hover:border-white/30 hover:text-white"
+                >
+                  →
+                </button>
+                {activeGame?.rawgUrl ? (
+                  <a
+                    href={activeGame.rawgUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="hidden sm:inline-flex pressable rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70 hover:border-white/30 hover:text-white"
+                  >
+                    RAWG
+                  </a>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => setFlowOpen(false)}
+                  className={[
+                    "pressable rounded-full border border-[color:var(--color-brand)] bg-[color:var(--color-brand)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-black shadow-[var(--shadow-glow)]",
+                    barCollapsed ? "hidden sm:inline-flex" : "",
+                  ].join(" ")}
+                >
+                  Close
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setBarCollapsed((value) => !value)}
+                  className="pressable rounded-full border border-white/10 bg-white/10 px-3 py-2 text-xs uppercase tracking-[0.3em] text-white/70 hover:border-white/30 hover:text-white sm:hidden"
+                >
+                  {barCollapsed ? "⌃" : "⌄"}
+                </button>
+              </div>
+            </div>
+            {!barCollapsed ? (
+              <div className="scroll-minimal flex-1 snap-x snap-mandatory overflow-x-auto px-6 pb-4">
+                <div className="flex h-full items-center gap-4">
+                  {flowGames.map((game, index) => (
+                    <button
+                      key={`${game.id}-thumb`}
+                      type="button"
+                      onClick={() => {
+                        goToIndex(index);
+                      }}
+                      className={
+                        index === safeFlowIndex
+                          ? "relative flex h-full w-36 shrink-0 snap-start overflow-hidden rounded-[1rem] border border-white/40"
+                          : "relative flex h-full w-36 shrink-0 snap-start overflow-hidden rounded-[1rem] border border-white/10 opacity-70 hover:opacity-100"
+                      }
+                    >
+                      {game.backgroundImage ? (
+                        <img
+                          src={game.backgroundImage}
+                          alt={game.title}
+                          className="h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-white/10 via-white/5 to-black/40 text-[10px] uppercase tracking-[0.3em] text-white/60">
+                          {game.title}
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,19 @@
+Media data seeds
+
+The seed files in this folder are the starting point for the media fetch scripts.
+Add your favorites (Spotify track URLs, IMDb IDs, RAWG slugs) and run the
+scripts to regenerate the JSON used by the app.
+
+Seed files
+- data/games.seed.json
+
+Commands
+- node scripts/fetch-rawg.mjs
+
+Environment
+- RAWG_API_KEY (required for RAWG)
+
+Notes
+- RAWG requires attribution; the /games page includes a source link.
+- RAWG profile scraping: set `profileUrl` in data/games.seed.json and optional `profileSections`
+  (`owned`, `toplay`, `playing`, `beaten`, `dropped`, `yet`) to auto-seed your list.

--- a/data/games.seed.json
+++ b/data/games.seed.json
@@ -1,0 +1,9 @@
+{
+  "profileUrl": "https://rawg.io/@chrcit/games",
+  "profileSections": ["owned", "toplay"],
+  "games": [],
+  "example": {
+    "rawgSlug": "hades",
+    "featured": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "media:games": "bun scripts/fetch-rawg.mjs"
   },
   "dependencies": {
     "@c15t/react": "^1.8.2",

--- a/scripts/fetch-rawg.mjs
+++ b/scripts/fetch-rawg.mjs
@@ -1,0 +1,147 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const seedPath = new URL("../data/games.seed.json", import.meta.url);
+const outputPath = new URL("../app/data/games.json", import.meta.url);
+
+const apiKey = process.env.RAWG_API_KEY;
+if (!apiKey) {
+  console.error("Missing RAWG_API_KEY in the environment.");
+  process.exit(1);
+}
+
+const seedRaw = await readFile(seedPath, "utf8");
+const seed = JSON.parse(seedRaw);
+const games = Array.isArray(seed.games) ? seed.games : [];
+const profileUrl = typeof seed.profileUrl === "string" ? seed.profileUrl : null;
+const profileSections =
+  Array.isArray(seed.profileSections) && seed.profileSections.length
+    ? seed.profileSections
+    : ["owned", "toplay"];
+
+function extractClientParams(html) {
+  const marker = "window.CLIENT_PARAMS";
+  const start = html.indexOf(marker);
+  if (start === -1) return null;
+  const eq = html.indexOf("=", start);
+  const firstBrace = html.indexOf("{", eq);
+  if (firstBrace === -1) return null;
+
+  let depth = 0;
+  for (let i = firstBrace; i < html.length; i += 1) {
+    const char = html[i];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        const jsonText = html.slice(firstBrace, i + 1);
+        return JSON.parse(jsonText);
+      }
+    }
+  }
+
+  return null;
+}
+
+async function fetchProfileSlugs(url, sections) {
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+      Accept: "text/html",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`RAWG profile fetch failed: ${response.status}`);
+  }
+
+  const html = await response.text();
+  const clientParams = extractClientParams(html);
+  const profileGames = clientParams?.initialState?.profile?.games;
+  if (!profileGames) return [];
+
+  const slugs = new Set();
+  for (const section of sections) {
+    const list = profileGames[section]?.results;
+    if (!Array.isArray(list)) continue;
+    for (const game of list) {
+      if (game?.slug) slugs.add(game.slug);
+    }
+  }
+
+  return Array.from(slugs);
+}
+
+const manualEntries = games
+  .map((entry) => ({
+    slug: entry.rawgSlug ?? entry.slug ?? entry.id,
+    featured: Boolean(entry.featured),
+  }))
+  .filter((entry) => entry.slug);
+
+const entriesBySlug = new Map(
+  manualEntries.map((entry) => [entry.slug, entry]),
+);
+
+if (profileUrl) {
+  const profileSlugs = await fetchProfileSlugs(profileUrl, profileSections);
+  for (const slug of profileSlugs) {
+    if (!entriesBySlug.has(slug)) {
+      entriesBySlug.set(slug, { slug, featured: false });
+    }
+  }
+}
+
+const entries = Array.from(entriesBySlug.values());
+
+if (!entries.length) {
+  console.warn("No games found in seed or profile scrape.");
+  await writeFile(outputPath, "[]\n");
+  process.exit(0);
+}
+
+async function fetchGame(slug) {
+  const response = await fetch(
+    `https://api.rawg.io/api/games/${slug}?key=${apiKey}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`RAWG request failed: ${slug} (${response.status})`);
+  }
+
+  return response.json();
+}
+
+function stripHtml(value) {
+  if (!value || typeof value !== "string") return null;
+  return value.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim() || null;
+}
+
+const output = [];
+
+for (const entry of entries) {
+  const slug = entry.slug;
+  if (!slug) continue;
+
+  const game = await fetchGame(slug);
+
+  output.push({
+    id: game.id,
+    slug: game.slug,
+    title: game.name,
+    description: game.description_raw ?? stripHtml(game.description),
+    released: game.released ?? null,
+    backgroundImage: game.background_image ?? null,
+    genres: game.genres?.map((genre) => genre.name) ?? [],
+    developers: game.developers?.map((dev) => dev.name) ?? [],
+    platforms:
+      game.platforms?.map((platform) => platform.platform?.name) ?? [],
+    rating: game.rating ?? null,
+    metacritic: game.metacritic ?? null,
+    website: game.website ?? null,
+    rawgUrl: game.slug ? `https://rawg.io/games/${game.slug}` : null,
+    featured: Boolean(entry.featured),
+  });
+}
+
+await writeFile(outputPath, `${JSON.stringify(output, null, 2)}\n`);
+console.log(`Wrote ${output.length} games to app/data/games.json`);


### PR DESCRIPTION
Adds a RAWG-powered games page with a coverflow detail view and seeded data pipeline. Includes a fetch script and seed file for syncing your RAWG profile into app data. Also adds minimal scrollbar styling and a nav entry for the new page.